### PR TITLE
defaults.inc.php: Update comments for smtp wirh TLS

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -302,19 +302,19 @@ $config['smtp_xclient_addr'] = false;
 $config['smtp_helo_host'] = '';
 
 // SMTP connection timeout, in seconds. Default: 0 (use default_socket_timeout)
-// Note: There's a known issue where using ssl connection with
-// timeout > 0 causes connection errors (https://bugs.php.net/bug.php?id=54511)
 $config['smtp_timeout'] = 0;
 
 // SMTP socket context options
 // See http://php.net/manual/en/context.ssl.php
-// The example below enables server certificate validation, and
-// requires 'smtp_timeout' to be non zero.
+// The example below enables server certificate validation.
+// You may need SNI_server_name if the server requires it
+// (see bug https://bugs.php.net/bug.php?id=54511)
 // $config['smtp_conn_options'] = [
 //   'ssl'         => [
 //     'verify_peer'  => true,
 //     'verify_depth' => 3,
 //     'cafile'       => '/etc/openssl/certs/ca.crt',
+//     'SNI_server_name' => 'smtpb.scig.gov.hk'),
 //   ],
 // ];
 // Note: These can be also specified as an array of options indexed by hostname


### PR DESCRIPTION
The comment for smtp_conn_options suggested using smtp_timeout > 0 when using TLS.
The comment for smtp_timeout suggested that there is a bug when using 0 when using TLS. The references bug doesn't talk about smtp_fimeout at all, but that a server requiring SNI needs the connection parameter SNI_enabled.
I've uses TLS for smtp connections for several years and did use the default (=0) for smtp_timeout without problems. So let's remove the confusing and inconsistent comments and add SNI_enabled to the example.